### PR TITLE
Fix scale down related issues

### DIFF
--- a/scale/scale.go
+++ b/scale/scale.go
@@ -68,7 +68,7 @@ func (p *PodAutoScaler) ScaleUp() error {
 func (p *PodAutoScaler) ScaleDown() error {
 	deployment, err := p.Client.Deployments(api.NamespaceDefault).Get(p.Deployment)
 	if err != nil {
-		return errors.Wrap(err, "Failed to get deployment from kube server, no scale up occured")
+		return errors.Wrap(err, "Failed to get deployment from kube server, no scale down occured")
 	}
 
 	currentReplicas := deployment.Spec.Replicas

--- a/scale/scale.go
+++ b/scale/scale.go
@@ -66,7 +66,7 @@ func (p *PodAutoScaler) ScaleUp() error {
 }
 
 func (p *PodAutoScaler) ScaleDown() error {
-	deployment, err := p.Client.Deployments(api.NamespaceDefault).Get(p.Deployment)
+	deployment, err := p.Client.Deployments(p.Namespace).Get(p.Deployment)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get deployment from kube server, no scale down occured")
 	}


### PR DESCRIPTION
When trying to scale down a deployment which is in a custom namespace, the scale down does not work. The error output looks the following:

`time="2017-07-13T13:50:56Z" level=error msg="Failed scaling down: Failed to get deployment from kube server, no scale up occured: deployments.extensions \"custom-deployment\" not found" `

This pull request should hopefully fix the scale down and correct the error output.