### PR TITLE
Fix namespace mismatch when scaling down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test clean compile build push
 
 IMAGE=wattpad/kube-sqs-autoscaler
-VERSION=v1.2
+VERSION=v1.2.1
 
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: kube-sqs-autoscaler
-        image: wattpad/kube-sqs-autoscaler:v1.2
+        image: wattpad/kube-sqs-autoscaler:v1.2.1
         command:
           - /kube-sqs-autoscaler
           - --sqs-queue-url=https://sqs.your_aws_region.amazonaws.com/your_aws_account_number/your_queue_name  # required

--- a/scale/scale.go
+++ b/scale/scale.go
@@ -79,7 +79,7 @@ func (p *PodAutoScaler) ScaleDown() error {
 
 	deployment.Spec.Replicas = currentReplicas - 1
 
-	deployment, err = p.Client.Deployments(api.NamespaceDefault).Update(deployment)
+	deployment, err = p.Client.Deployments(p.Namespace).Update(deployment)
 	if err != nil {
 		return errors.Wrap(err, "Failed to scale down")
 	}

--- a/scale/scale.go
+++ b/scale/scale.go
@@ -5,7 +5,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 )


### PR DESCRIPTION
Unfortunately, my fix did produce a follow-up error in the namespace handling. The error looks:
`time="2017-07-18T13:09:30Z" level=error msg="Failed scaling down: Failed to scale down: the namespace of the object (mynamespace) does not match the namespace on the request (default)"`

This commit should now fix this mismatch. I also already updated the version for your convinience :)