### PR TITLE
Silence 'Errors' when scaling up/down can't happen due to having reached target

### DIFF
--- a/scale/scale.go
+++ b/scale/scale.go
@@ -49,8 +49,12 @@ func (p *PodAutoScaler) ScaleUp() error {
 
 	currentReplicas := deployment.Spec.Replicas
 
-	if currentReplicas >= int32(p.Max) {
-		return errors.New("Max pods reached")
+  if currentReplicas == int32(p.Max) {
+	  return nil
+	}
+
+  if currentReplicas > int32(p.Max) {
+		return errors.New("More than max pods running")
 	}
 
 	deployment.Spec.Replicas = currentReplicas + 1
@@ -72,8 +76,12 @@ func (p *PodAutoScaler) ScaleDown() error {
 
 	currentReplicas := deployment.Spec.Replicas
 
-	if currentReplicas <= int32(p.Min) {
-		return errors.New("Min pods reached")
+	if currentReplicas == int32(p.Min) {
+	  return nil
+	}
+
+	if currentReplicas < int32(p.Min) {
+		return errors.New("Less than min pods running")
 	}
 
 	deployment.Spec.Replicas = currentReplicas - 1

--- a/scale/scale_test.go
+++ b/scale/scale_test.go
@@ -14,7 +14,7 @@ func TestScaleUp(t *testing.T) {
 	p := NewMockPodAutoScaler("test", "test", 5, 1)
 
 	// Scale up replicas until we reach the max (5).
-	// Scale up again and assert that we get an error back when trying to scale up replicas pass the max
+	// Scale up again and assert that we do not get an error but nothing happens
 	err := p.ScaleUp()
 	deployment, _ := p.Client.Deployments("test").Get("test")
 	assert.Nil(t, err)
@@ -25,7 +25,7 @@ func TestScaleUp(t *testing.T) {
 	assert.Equal(t, int32(5), deployment.Spec.Replicas)
 
 	err = p.ScaleUp()
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 	deployment, _ = p.Client.Deployments("test").Get("test")
 	assert.Equal(t, int32(5), deployment.Spec.Replicas)
 }
@@ -43,7 +43,7 @@ func TestScaleDown(t *testing.T) {
 	assert.Equal(t, int32(1), deployment.Spec.Replicas)
 
 	err = p.ScaleDown()
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 	deployment, _ = p.Client.Deployments("test").Get("test")
 	assert.Equal(t, int32(1), deployment.Spec.Replicas)
 }


### PR DESCRIPTION
This 'could' be logged, but definitely isn't an error case